### PR TITLE
"correction README.md and script bash"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Diffusion/Usage/Modifications librement autorisées à condition de citer la sou
 
 Nécessite Java 8 minimum. Compiler avec la commande :
 ```
-javac Main
+javac Main.java
 ```
 Usage<br />
 ./Generateur_ANFR.sh anfr<br />

--- a/java/Generateur_ANFR.sh
+++ b/java/Generateur_ANFR.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -cp "./lib/*:./" Main $1
+script_path="$(realpath "$0")"
+DIR_script="$(dirname "${script_path}")"
+java -cp "${DIR_script}/lib/sqlite-jdbc-3.36.0.1.jar:${DIR_script}/" Main $1


### PR DESCRIPTION
README.md and script bash

    "javac Main" in README.md : error: Class names, 'Main', are only accepted if annotation processing is explicitly requested

    "bash Generateur_ANFR.sh"
    Error: Could not find or load main class Main
    Caused by: java.lang.ClassNotFoundException: Main