### PR TITLE
Fix error script bash on Windows 'MINGW'

### DIFF
--- a/java/Generateur_ANFR.sh
+++ b/java/Generateur_ANFR.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
-script_path="$(realpath "$0")"
-DIR_script="$(dirname "${script_path}")"
-java -cp "${DIR_script}/lib/*:${DIR_script}/" Main $1
+unameOut="$(uname -s)"
+case "${unameOut}" in
+	Linux*)     java -cp "./lib/*:./" Main $1;;
+	#arwin*)    
+	#YGWIN*)    
+	MINGW*)     java -cp "./lib/*;./" Main $1;;
+	*)          java -cp "./lib/*:./" Main $1;;
+esac


### PR DESCRIPTION
	error message :
		Error: Could not find or load main class Main
		Caused by: java.lang.ClassNotFoundException: Main

	Sources : https://stackoverflow.com/questions/219585/including-all-te-jars-in-a-direcory-wihin-the-jahttva-classpath
